### PR TITLE
Simplify the Organizational Unit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This repository holds a Terraform module that creates organisational units and a
 ```
 module "environments" {
   source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments"
-  environment_types                  = ["production", "non-production"]
   environment_directory              = "./environments"
   environment_parent_organisation_id = "ou-123456789"
   environment_prefix                 = "modernisation-platform"
@@ -14,12 +13,11 @@ module "environments" {
 ```
 
 ## Inputs
-|      Name     |               Description              |  Type  | Default | Required |
-|:-------------:|:--------------------------------------:|:------:|:-------:|----------|
-| environment_types | Environment types (or subfolders) in the environments directory | list | n/a     | yes      |
-| environment_directory | Directory path for environment definitions | string | n/a     | yes      |
-| environment_parent_organisation_id | Organisation ID for newly configured environments to sit within | string | n/a     | yes      |
-| environment_prefix | Prefix for all new environment and account names | string | n/a     | yes      |
+|                Name                |                           Description                           |  Type  | Default | Required |
+|:----------------------------------:|:---------------------------------------------------------------:|:------:|:-------:|----------|
+|        environment_directory       |            Directory path for environment definitions           | string |   n/a   | yes      |
+| environment_parent_organisation_id | Organisation ID for newly configured environments to sit within | string |   n/a   | yes      |
+|         environment_prefix         |         Prefix for all new environment and account names        | string |   n/a   | yes      |
 
 ## Outputs
 | Name                    | Description                                | Sensitive |

--- a/main.tf
+++ b/main.tf
@@ -1,52 +1,42 @@
-provider "aws" {}
-
 locals {
-  applications = flatten([
-    for type in var.environment_types : [
-      for application in fileset("${var.environment_directory}/${type}", "*.json") : {
-        application = jsondecode(file("${var.environment_directory}/${type}/${application}"))
-        namespace   = type
-      }
+  definitions = [
+    for file in fileset("${var.environment_directory}", "*.json") :
+    jsondecode(file("${var.environment_directory}/${file}"))
+  ]
+  applications = {
+    organization_units = [
+      for application in local.definitions : application.name
     ]
-  ])
-  application_ous = {
-    for definition in local.applications :
-    definition.application.name => definition.namespace
-  }
-  application_envs = flatten([
-    for definition in local.applications : [
-      for env in definition.application.environments : {
-        definition = definition
-        namespace  = env
-      }
-    ]
-  ])
-  application_envs_accounts = {
-    for account in local.application_envs :
-    "${account.definition.application.name}-${account.namespace}" => account
+    accounts = flatten([
+      for application in local.definitions : [
+        for environment in application.environments : {
+          name    = "${application.name}-${environment}"
+          part_of = application.name
+          tags    = merge(application.tags, {
+            is-production = (environment == "production") ? true : false
+            environment-name = environment
+          })
+        }
+      ]
+    ])
   }
 }
 
-# Create environment type organisation units
-resource "aws_organizations_organizational_unit" "types" {
-  for_each  = toset(var.environment_types)
+# Create each application an Organizational Unit
+resource "aws_organizations_organizational_unit" "applications" {
+  for_each  = toset(local.applications.organization_units)
   name      = "${var.environment_prefix}-${each.value}"
   parent_id = var.environment_parent_organisation_id
 }
 
-# Create application organisation units
-resource "aws_organizations_organizational_unit" "applications" {
-  for_each  = local.application_ous
-  name      = "${var.environment_prefix}-${each.key}-${each.value}"
-  parent_id = aws_organizations_organizational_unit.types[each.value].id
-}
-
-# Create application accounts in their respective OUs
+# Create each application's environments an account within their own Organizational Unit
 resource "aws_organizations_account" "accounts" {
-  for_each                   = local.application_envs_accounts
-  name                       = each.key
-  email                      = "aws+mp+${each.key}@digital.justice.gov.uk"
+  for_each = {
+    for account in local.applications.accounts : account.name => account
+  }
+  name                       = each.value.name
+  email                      = "aws+mp+${each.value.name}@digital.justice.gov.uk"
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.applications[each.value.definition.application.name].id
-  tags                       = each.value.definition.application.tags
+  parent_id                  = aws_organizations_organizational_unit.applications[each.value.part_of].id
+  tags                       = each.value.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,8 @@ locals {
         for environment in application.environments : {
           name    = "${application.name}-${environment}"
           part_of = application.name
-          tags    = merge(application.tags, {
-            is-production = (environment == "production") ? true : false
+          tags = merge(application.tags, {
+            is-production    = (environment == "production") ? true : false
             environment-name = environment
           })
         }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "environment_types" {
-  description = "Environment types (or subfolders) in the environments directory"
-  type        = list
-}
-
 variable "environment_directory" {
   description = "Directory path for environment definitions"
   type        = string


### PR DESCRIPTION
This PR removes a layer of AWS Organizational Units from a non-production/production layer to a simpler separated application layer. This should create a cleaner structure of OUs and associated accounts within the Modernisation Platform, alongside access management to each application, and further removes a bit of complexity around the code.

This PR also removes a rogue `provider` definition, removes the `environment_types` variable and infers the `is-production` and `environment-name` tags from the [MoJ Technical Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure).