### PR TITLE
Fix interpolation deprecation notice

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   definitions = [
-    for file in fileset("${var.environment_directory}", "*.json") :
+    for file in fileset(var.environment_directory, "*.json") :
     jsondecode(file("${var.environment_directory}/${file}"))
   ]
   applications = {


### PR DESCRIPTION
This PR fixes a deprecation notice for interpolation-only strings in Terraform.