### PR TITLE
Change checkout to main and update README

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -6,7 +6,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+*.terraform*

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "environments" {
 ## Outputs
 | Name                    | Description                                | Sensitive |
 |-------------------------|--------------------------------------------|-----------|
-| environment_account_ids | Account IDs for the newly created accounts | Yes       |
+| environment_account_ids | Account IDs for the newly created accounts | yes       |
 
 ## Looking for issues?
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).


### PR DESCRIPTION
- Updates README to use lowercase `yes` to match other repositories
- Changes the GitHub action for checkout to use branch `main` rather than `master`