### PR TITLE
Ignore changes to organisation accounts so they're not forcefully replaced

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,4 +39,11 @@ resource "aws_organizations_account" "accounts" {
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.applications[each.value.part_of].id
   tags                       = each.value.tags
+
+  # Changing the name or email forces a replacement of the account,
+  # which means the AWS account will be detached from the organisation,
+  # so we want to ignore any of those changes
+  lifecycle {
+    ignore_changes = [name, email]
+  }
 }


### PR DESCRIPTION
If you change an `aws_organizations_account` `name` or `email`, it forces a replacement of the resource. If you destroy a resource, it becomes detached from the organisation _but not deleted_. By ignoring the `name` or `email` changes, we can rename them _locally_ without them being forcefully replaced _remotely_ within AWS Organizations.