### PR TITLE
Use key for output, rather than account.name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 output "environment_account_ids" {
   sensitive = true
   value = {
-    for account in aws_organizations_account.accounts :
-    account.name => account.id
+    for key, account in aws_organizations_account.accounts :
+    key => account.id
   }
 }


### PR DESCRIPTION
By using the Terraform `key`, rather than `account.name`, for mapping accounts to their respective IDs, we can locally change account names without having to destroy a resource, and this output will now output the _correct_ mapping rather than the old names themselves (since remotely they won't change).