### PR TITLE
Generate random email address for: uniqueness and a managed character length

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,17 @@ locals {
   }
 }
 
+# Generate a random string to use for an email address for each account
+resource "random_string" "email-address" {
+  for_each = {
+    for account in local.applications.accounts : account.name => account
+  }
+
+  length  = 16
+  special = false
+  upper   = false
+}
+
 # Create each application an Organizational Unit
 resource "aws_organizations_organizational_unit" "applications" {
   for_each  = toset(local.applications.organization_units)
@@ -33,10 +44,12 @@ resource "aws_organizations_organizational_unit" "applications" {
 # Create each application's environments an account within their own Organizational Unit
 resource "aws_organizations_account" "accounts" {
   for_each = {
-    for account in local.applications.accounts : account.name => account
+    for account in local.applications.accounts : account.name => merge(account, {
+      email = "aws+mp+${random_string.email-address[account.name].result}@digital.justice.gov.uk"
+    })
   }
   name                       = each.value.name
-  email                      = "aws+mp+${each.value.name}@digital.justice.gov.uk"
+  email                      = each.value.email
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.applications[each.value.part_of].id
   tags                       = each.value.tags


### PR DESCRIPTION
AWS currently validates email address length, which can't be more than 64 characters when creating an account.

This replaces the setting of email addresses to a randomised alias that is 16 characters in length, to help us manage the string length of emails (now always 16 characters) and ensures uniqueness, which is also required if an AWS account is closed, and then attempted to be recreated with the same email address.