### PR TITLE
Fix provider versions and add output description

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,4 +4,5 @@ output "environment_account_ids" {
     for key, account in aws_organizations_account.accounts :
     key => account.id
   }
+  description = "Map of account keys and their IDs (e.g. { account_name => 1234567890 })"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,12 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR fixes provider versions to use the correct minimum `aws` and `random` provider versions.

It also adds a missing output description for account IDs.