### PR TITLE
create-sub-OUs-from-mod-platform-repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ locals {
   applications = {
     organization_units = [
       for application in local.definitions : {
-      application_name = application.name
-      type             = application.account-type
+        application_name = application.name
+        type             = application.account-type
       }
     ]
-    
+
     accounts = flatten([
       for application in local.definitions : [
         for environment in application.environments : {
@@ -62,11 +62,11 @@ resource "aws_organizations_organizational_unit" "platforms-and-architecture-mod
 
 # Create each application an Organizational Unit
 resource "aws_organizations_organizational_unit" "applications" {
-  for_each = {for idx, query in local.applications.organization_units: query.application_name => query}
+  for_each = { for idx, query in local.applications.organization_units : query.application_name => query }
 
   name      = "${var.environment_prefix}-${each.value.application_name}"
   parent_id = each.value.type == "core" ? aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core.id : each.value.type == "member" ? aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member.id : aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member-unrestricted.id
- }
+}
 
 
 # Create each application's environments an account within their own Organizational Unit
@@ -81,7 +81,7 @@ resource "aws_organizations_account" "accounts" {
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.applications[each.value.part_of].id
 
-  tags                       = each.value.tags
+  tags = each.value.tags
 
   # Changing the name or email forces a replacement of the account,
   # which means the AWS account will be detached from the organisation,

--- a/main.tf
+++ b/main.tf
@@ -4,10 +4,15 @@ locals {
       name = replace(file, ".json", "")
     }, jsondecode(file("${var.environment_directory}/${file}")))
   ]
+
   applications = {
     organization_units = [
-      for application in local.definitions : application.name
+      for application in local.definitions : {
+      application_name = application.name
+      type             = application.account-type
+      }
     ]
+    
     accounts = flatten([
       for application in local.definitions : [
         for environment in application.environments : {
@@ -34,12 +39,35 @@ resource "random_string" "email-address" {
   upper   = false
 }
 
-# Create each application an Organizational Unit
-resource "aws_organizations_organizational_unit" "applications" {
-  for_each  = toset(local.applications.organization_units)
-  name      = "${var.environment_prefix}-${each.value}"
+# # There are more OUs within the Modernisation Platform Core, but they are managed elsewhere
+# See: https://github.com/ministryofjustice/modernisation-platform
+resource "aws_organizations_organizational_unit" "platforms-and-architecture-modernisation-platform-core" {
+  name      = "Modernisation Platform Core"
   parent_id = var.environment_parent_organisation_id
 }
+
+# There are more OUs within the Modernisation Platform Member, but they are managed elsewhere
+# See: https://github.com/ministryofjustice/modernisation-platform
+resource "aws_organizations_organizational_unit" "platforms-and-architecture-modernisation-platform-member" {
+  name      = "Modernisation Platform Member"
+  parent_id = var.environment_parent_organisation_id
+}
+
+# There are more OUs within the Modernisation Platform Member Unrestricted, but they are managed elsewhere
+# See: https://github.com/ministryofjustice/modernisation-platform
+resource "aws_organizations_organizational_unit" "platforms-and-architecture-modernisation-platform-member-unrestricted" {
+  name      = "Modernisation Platform Member Unrestricted"
+  parent_id = var.environment_parent_organisation_id
+}
+
+# Create each application an Organizational Unit
+resource "aws_organizations_organizational_unit" "applications" {
+  for_each = {for idx, query in local.applications.organization_units: query.application_name => query}
+
+  name      = "${var.environment_prefix}-${each.value.application_name}"
+  parent_id = each.value.type == "core" ? aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core.id : each.value.type == "member" ? aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member.id : aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member-unrestricted.id
+ }
+
 
 # Create each application's environments an account within their own Organizational Unit
 resource "aws_organizations_account" "accounts" {
@@ -52,6 +80,7 @@ resource "aws_organizations_account" "accounts" {
   email                      = each.value.email
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.applications[each.value.part_of].id
+
   tags                       = each.value.tags
 
   # Changing the name or email forces a replacement of the account,

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,15 +9,15 @@ output "environment_account_ids" {
 
 output "modernisation_platform_core_ou_id" {
   sensitive = true
-  value = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core.id
+  value     = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core.id
 }
 
 output "modernisation_platform_member_ou_id" {
   sensitive = true
-  value = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member.id
+  value     = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member.id
 }
 
 output "modernisation_platform_member_unrestricted_ou_id" {
   sensitive = true
-  value = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member-unrestricted.id
+  value     = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member-unrestricted.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,3 +6,18 @@ output "environment_account_ids" {
   }
   description = "Map of account keys and their IDs (e.g. { account_name => 1234567890 })"
 }
+
+output "modernisation_platform_core_ou_id" {
+  sensitive = true
+  value = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core.id
+}
+
+output "modernisation_platform_member_ou_id" {
+  sensitive = true
+  value = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member.id
+}
+
+output "modernisation_platform_member_unrestricted_ou_id" {
+  sensitive = true
+  value = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member-unrestricted.id
+}


### PR DESCRIPTION
- created sub OUs off of Modernisation-Platform OU for core, member and
  member-restricted
- moved all Modernisation-Platform member OUs into one of the above new
  OUs, this is controlled via the environments JSON files
- moved member accounts into new OUs

OU structure change is required to enable better control of different
accounts types using SCPs