### PR TITLE
Add new outputs for Autonuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,58 @@ module "environments" {
 }
 ```
 
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.47.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.47.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_organizations_account.accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_account) | resource |
+| [aws_organizations_organizational_unit.applications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organizational_unit) | resource |
+| [aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organizational_unit) | resource |
+| [aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organizational_unit) | resource |
+| [aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-member-unrestricted](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organizational_unit) | resource |
+| [random_string.email-address](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+
 ## Inputs
 
-|                Name                |                           Description                           |  Type  | Default | Required |
-| :--------------------------------: | :-------------------------------------------------------------: | :----: | :-----: | -------- |
-|       environment_directory        |           Directory path for environment definitions            | string |   n/a   | yes      |
-| environment_parent_organisation_id | Organisation ID for newly configured environments to sit within | string |   n/a   | yes      |
-|         environment_prefix         |        Prefix for all new environment and account names         | string |   n/a   | yes      |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_environment_directory"></a> [environment\_directory](#input\_environment\_directory) | Directory path for environment definitions | `string` | n/a | yes |
+| <a name="input_environment_parent_organisation_id"></a> [environment\_parent\_organisation\_id](#input\_environment\_parent\_organisation\_id) | Organisation ID for newly configured environments to sit within | `string` | n/a | yes |
+| <a name="input_environment_prefix"></a> [environment\_prefix](#input\_environment\_prefix) | Prefix for all new environment and account names | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                    | Description                                | Sensitive |
-| ----------------------- | ------------------------------------------ | --------- |
-| environment_account_ids | Account IDs for the newly created accounts | yes       |
+| Name | Description |
+|------|-------------|
+| <a name="output_environment_account_ids"></a> [environment\_account\_ids](#output\_environment\_account\_ids) | Map of account keys and their IDs (e.g. { account\_name => 1234567890 }) |
+| <a name="output_environment_nuke_accounts"></a> [environment\_nuke\_accounts](#output\_environment\_nuke\_accounts) | List of autonuke account names. |
+| <a name="output_environment_nuke_blocklist_accounts"></a> [environment\_nuke\_blocklist\_accounts](#output\_environment\_nuke\_blocklist\_accounts) | List of account names blocklisted from autonuke. |
+| <a name="output_environment_rebuild_after_nuke_accounts"></a> [environment\_rebuild\_after\_nuke\_accounts](#output\_environment\_rebuild\_after\_nuke\_accounts) | List of rebuild-after-autonuke account names. |
+| <a name="output_modernisation_platform_core_ou_id"></a> [modernisation\_platform\_core\_ou\_id](#output\_modernisation\_platform\_core\_ou\_id) | n/a |
+| <a name="output_modernisation_platform_member_ou_id"></a> [modernisation\_platform\_member\_ou\_id](#output\_modernisation\_platform\_member\_ou\_id) | n/a |
+| <a name="output_modernisation_platform_member_unrestricted_ou_id"></a> [modernisation\_platform\_member\_unrestricted\_ou\_id](#output\_modernisation\_platform\_member\_unrestricted\_ou\_id) | n/a |
+
+<!-- END_TF_DOCS -->
 
 ## Looking for issues?
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,14 @@ locals {
         } if application.account-type == "member" && environment.name == "development" && try(environment.access[0].level, "undefined") == "sandbox" && try(environment.access[0].nuke, "include") == "rebuild"
       ]
     ])
+
+    blacklist_nuke_accounts = flatten([
+      for application in local.definitions : [
+        for environment in application.environments : {
+          name = "${application.name}-${environment.name}"
+        } if environment.name == "production" || environment.name == "preproduction" || startswith(application.name, "core")
+      ]
+    ])
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ locals {
       ]
     ])
 
-    blacklist_nuke_accounts = flatten([
+    blocklist_nuke_accounts = flatten([
       for application in local.definitions : [
         for environment in application.environments : {
           name = "${application.name}-${environment.name}"

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,22 @@ locals {
         }
       ]
     ])
+
+    nuke_accounts = flatten([
+      for application in local.definitions : [
+        for environment in application.environments : {
+          name = "${application.name}-${environment.name}"
+        } if application.account-type == "member" && environment.name == "development" && try(environment.access[0].level, "undefined") == "sandbox" && try(environment.access[0].nuke, "include") != "exclude"
+      ]
+    ])
+
+    rebuild_after_nuke_accounts = flatten([
+      for application in local.definitions : [
+        for environment in application.environments : {
+          name = "${application.name}-${environment.name}"
+        } if application.account-type == "member" && environment.name == "development" && try(environment.access[0].level, "undefined") == "sandbox" && try(environment.access[0].nuke, "include") == "rebuild"
+      ]
+    ])
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,16 +7,22 @@ output "environment_account_ids" {
   description = "Map of account keys and their IDs (e.g. { account_name => 1234567890 })"
 }
 
-output "environment_nuke_account_ids" {
+output "environment_nuke_accounts" {
   sensitive = true
   value = local.applications.nuke_accounts[*].name
   description = "List of autonuke account names."
 }
 
-output "environment_rebuild_after_nuke_account_ids" {
+output "environment_rebuild_after_nuke_accounts" {
   sensitive = true
   value = local.applications.rebuild_after_nuke_accounts[*].name
   description = "List of rebuild-after-autonuke account names."
+}
+
+output "environment_nuke_blacklist_accounts" {
+  sensitive = true
+  value = local.applications.blacklist_nuke_accounts[*].name
+  description = "List of account names blacklisted from autonuke."
 }
 
 output "modernisation_platform_core_ou_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,10 +19,10 @@ output "environment_rebuild_after_nuke_accounts" {
   description = "List of rebuild-after-autonuke account names."
 }
 
-output "environment_nuke_blacklist_accounts" {
+output "environment_nuke_blocklist_accounts" {
   sensitive = true
-  value = local.applications.blacklist_nuke_accounts[*].name
-  description = "List of account names blacklisted from autonuke."
+  value = local.applications.blocklist_nuke_accounts[*].name
+  description = "List of account names blocklisted from autonuke."
 }
 
 output "modernisation_platform_core_ou_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,18 @@ output "environment_account_ids" {
   description = "Map of account keys and their IDs (e.g. { account_name => 1234567890 })"
 }
 
+output "environment_nuke_account_ids" {
+  sensitive = true
+  value = local.applications.nuke_accounts[*].name
+  description = "List of autonuke account names."
+}
+
+output "environment_rebuild_after_nuke_account_ids" {
+  sensitive = true
+  value = local.applications.rebuild_after_nuke_accounts[*].name
+  description = "List of rebuild-after-autonuke account names."
+}
+
 output "modernisation_platform_core_ou_id" {
   sensitive = true
   value     = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform-core.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,20 +8,20 @@ output "environment_account_ids" {
 }
 
 output "environment_nuke_accounts" {
-  sensitive = true
-  value = local.applications.nuke_accounts[*].name
+  sensitive   = true
+  value       = local.applications.nuke_accounts[*].name
   description = "List of autonuke account names."
 }
 
 output "environment_rebuild_after_nuke_accounts" {
-  sensitive = true
-  value = local.applications.rebuild_after_nuke_accounts[*].name
+  sensitive   = true
+  value       = local.applications.rebuild_after_nuke_accounts[*].name
   description = "List of rebuild-after-autonuke account names."
 }
 
 output "environment_nuke_blocklist_accounts" {
-  sensitive = true
-  value = local.applications.blocklist_nuke_accounts[*].name
+  sensitive   = true
+  value       = local.applications.blocklist_nuke_accounts[*].name
   description = "List of account names blocklisted from autonuke."
 }
 


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2400

Creating three dynamically generated outputs which will then be passed to the autonuke script via GitHub Actions Secrets

- `environment_nuke_accounts`: all sandbox accounts which are not explicitly annotated with `"nuke" : "exclude"` in the environment json file
- `environment_rebuild_after_nuke_accounts`: list of accounts to be rebuilt after autonuke completes. Annotated with `"nuke": "rebuild"` in the environments json files
- `blocklist_nuke_accounts`: all preproduction, production and core accounts.