### PR TITLE
Refactoring nuke-related local definitions to account for one, many or no defined access blocks.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,21 +26,22 @@ locals {
       ]
     ])
 
-    nuke_accounts = flatten([
+    nuke_accts = flatten([
       for application in local.definitions : [
         for environment in application.environments : [
           for a in try(environment.access, []) :
           "${application.name}-${environment.name}"
-          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && try(a.nuke, "include") != "exclude"
+          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && !contains([for acc in environment.access : try(acc.nuke, "include") if try(acc.level, "undefined") == "sandbox"], "exclude")
         ]
     ]])
+
 
     rebuild_after_nuke_accounts = flatten([
       for application in local.definitions : [
         for environment in application.environments : [
           for a in try(environment.access, []) :
           "${application.name}-${environment.name}"
-          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && try(a.nuke, "include") == "rebuild"
+          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && try(a.nuke, "include") == "rebuild" && !contains([for acc in environment.access : try(acc.nuke, "include") if try(acc.level, "undefined") == "sandbox"], "exclude")
         ]
       ]
     ])
@@ -48,8 +49,8 @@ locals {
     blocklist_nuke_accounts = flatten([
       for application in local.definitions : [
         for environment in application.environments :
-          "${application.name}-${environment.name}"
-          if environment.name == "production" || environment.name == "preproduction" || startswith(application.name, "core")
+        "${application.name}-${environment.name}"
+        if environment.name == "production" || environment.name == "preproduction" || startswith(application.name, "core")
       ]
     ])
   }

--- a/main.tf
+++ b/main.tf
@@ -28,25 +28,28 @@ locals {
 
     nuke_accounts = flatten([
       for application in local.definitions : [
-        for environment in application.environments : {
-          name = "${application.name}-${environment.name}"
-        } if application.account-type == "member" && environment.name == "development" && try(environment.access[0].level, "undefined") == "sandbox" && try(environment.access[0].nuke, "include") != "exclude"
-      ]
-    ])
+        for environment in application.environments : [
+          for a in try(environment.access, []) :
+          "${application.name}-${environment.name}"
+          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && try(a.nuke, "include") != "exclude"
+        ]
+    ]])
 
     rebuild_after_nuke_accounts = flatten([
       for application in local.definitions : [
-        for environment in application.environments : {
-          name = "${application.name}-${environment.name}"
-        } if application.account-type == "member" && environment.name == "development" && try(environment.access[0].level, "undefined") == "sandbox" && try(environment.access[0].nuke, "include") == "rebuild"
+        for environment in application.environments : [
+          for a in try(environment.access, []) :
+          "${application.name}-${environment.name}"
+          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && try(a.nuke, "include") == "rebuild"
+        ]
       ]
     ])
 
     blocklist_nuke_accounts = flatten([
       for application in local.definitions : [
-        for environment in application.environments : {
-          name = "${application.name}-${environment.name}"
-        } if environment.name == "production" || environment.name == "preproduction" || startswith(application.name, "core")
+        for environment in application.environments :
+          "${application.name}-${environment.name}"
+          if environment.name == "production" || environment.name == "preproduction" || startswith(application.name, "core")
       ]
     ])
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,19 +9,19 @@ output "environment_account_ids" {
 
 output "environment_nuke_accounts" {
   sensitive   = true
-  value       = local.applications.nuke_accounts[*].name
+  value       = flatten(local.applications.nuke_accounts)
   description = "List of autonuke account names."
 }
 
 output "environment_rebuild_after_nuke_accounts" {
   sensitive   = true
-  value       = local.applications.rebuild_after_nuke_accounts[*].name
+  value       = flatten(local.applications.rebuild_after_nuke_accounts)
   description = "List of rebuild-after-autonuke account names."
 }
 
 output "environment_nuke_blocklist_accounts" {
   sensitive   = true
-  value       = local.applications.blocklist_nuke_accounts[*].name
+  value       = flatten(local.applications.blocklist_nuke_accounts)
   description = "List of account names blocklisted from autonuke."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,19 +9,19 @@ output "environment_account_ids" {
 
 output "environment_nuke_accounts" {
   sensitive   = true
-  value       = flatten(local.applications.nuke_accounts)
+  value       = distinct(local.applications.nuke_accounts)
   description = "List of autonuke account names."
 }
 
 output "environment_rebuild_after_nuke_accounts" {
   sensitive   = true
-  value       = flatten(local.applications.rebuild_after_nuke_accounts)
+  value       = distinct(local.applications.rebuild_after_nuke_accounts)
   description = "List of rebuild-after-autonuke account names."
 }
 
 output "environment_nuke_blocklist_accounts" {
   sensitive   = true
-  value       = flatten(local.applications.blocklist_nuke_accounts)
+  value       = local.applications.blocklist_nuke_accounts
   description = "List of account names blocklisted from autonuke."
 }
 


### PR DESCRIPTION
* `nuke_account` and `rebuild_after_nuke_accounts` will accept multiple `access` blocks. Account will only be added to the lists if `access.level` of any of the development access blocks is equal to `sandbox`
* If multiple sandbox access blocks are defined for a development account, with multiple values for `"nuke"` `exclude` will take priority.
* blocklist_nuke_account refactored for consistency.

Relevant Story: https://github.com/ministryofjustice/modernisation-platform/issues/2400
