### PR TITLE
Refactored locals that select nuke accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,21 +28,23 @@ locals {
 
     nuke_accounts = flatten([
       for application in local.definitions : [
-        for environment in application.environments : [
-          for a in try(environment.access, []) :
-          "${application.name}-${environment.name}"
-          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && !contains([for acc in environment.access : try(acc.nuke, "include") if try(acc.level, "undefined") == "sandbox"], "exclude")
-        ]
-    ]])
-
+        for environment in application.environments :
+        "${application.name}-${environment.name}"
+        if application.account-type == "member"
+        && environment.name == "development"
+        && contains([for a in try(environment.access, []) : try(a.level, "undefined")], "sandbox")
+        && try(environment.nuke, "include") != "exclude"
+      ]
+    ])
 
     rebuild_after_nuke_accounts = flatten([
       for application in local.definitions : [
-        for environment in application.environments : [
-          for a in try(environment.access, []) :
-          "${application.name}-${environment.name}"
-          if application.account-type == "member" && environment.name == "development" && try(a.level, "undefined") == "sandbox" && try(a.nuke, "include") == "rebuild" && !contains([for acc in environment.access : try(acc.nuke, "include") if try(acc.level, "undefined") == "sandbox"], "exclude")
-        ]
+        for environment in application.environments :
+        "${application.name}-${environment.name}"
+        if application.account-type == "member"
+        && environment.name == "development"
+        && contains([for a in try(environment.access, []) : try(a.level, "undefined")], "sandbox")
+        && try(environment.nuke, "include") == "rebuild"
       ]
     ])
 


### PR DESCRIPTION
This PR is tracked upstream in the [modernisation-platform](https://github.com/ministryofjustice/modernisation-platform/) repository by [#9239](https://github.com/ministryofjustice/modernisation-platform/issues/9239).

This PR amends the local values used to select AWS accounts for inclusion in our AWS Nuke jobs, and accounts to be rebuilt following an AWS Nuke job.