### PR TITLE
Remove `+mp` tag as O365 groups do not accept multiple tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_organizations_organizational_unit" "applications" {
 resource "aws_organizations_account" "accounts" {
   for_each = {
     for account in local.applications.accounts : account.name => merge(account, {
-      email = "aws+mp+${random_string.email-address[account.name].result}@digital.justice.gov.uk"
+      email = "aws+${random_string.email-address[account.name].result}@digital.justice.gov.uk"
     })
   }
   name                       = each.value.name


### PR DESCRIPTION
# Why?

https://github.com/ministryofjustice/modernisation-platform/issues/9527

# What's Changed?

I've removed the `+mp` tag as moving forward we will be migrating to o365 groups which only support a single tag (e.g. a single `+`)

This will ensure that all new accounts conform to the new standard and we will continue to be able to access emails etc.