### PR TITLE
Update aws provider to v6

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10509

## Changes
Updates aws TF provider to v6